### PR TITLE
Fix deprecate construct same name as their class

### DIFF
--- a/mathpublisher.php
+++ b/mathpublisher.php
@@ -768,7 +768,7 @@ class expression
 class expression_texte extends expression
 {
 
-    function expression_texte($exp)
+    function __construct($exp)
     {
         $this->texte = $exp;
     }
@@ -785,7 +785,7 @@ class expression_math extends expression
 {
     var $noeuds;
 
-    function expression_math($exp)
+    function __construct($exp)
     {
         $this->texte = "&$";
         $this->noeuds = $exp;


### PR DESCRIPTION
In php 7 Deprecated construct same name as their class 
http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors